### PR TITLE
Update utils.py to match new (old) descriptions

### DIFF
--- a/custom_components/avfallsor/utils.py
+++ b/custom_components/avfallsor/utils.py
@@ -42,8 +42,8 @@ def find_next_garbage_pickup(dates):
 gb_map = {
     "rest": "Restavfall",
     "bio": "Bioavfall",
-    "paper": "Papir/papp",
-    "plastic": "Papir/papp",
+    "paper": "Papp, papir og plastemballasje",
+    "plastic": "Papp, papir og plastemballasje",
     "metal": "Glass- og metallemballasje",
 }
 gb_map.update({v: k for k, v in gb_map.items()})


### PR DESCRIPTION
Seems like the site went back to the original descriptions. This reverts https://github.com/custom-components/sensor.avfallsor/pull/15

There's probably a more clever way to fix this if they should choose to change back again (check for both strings?), but this works for the time being.